### PR TITLE
fix:modify arg for NewLevel fuction. 'level' is unnecessary.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ and the log level and response code associated with it.
 ## Installation
 
 ```sh
-go install gitlab.com/future-architect/reguerr/cmd/reguerr@latest
+go install github.com/future-architect/reguerr/cmd/reguerr@latest
 ```
 
 ## Options
@@ -46,7 +46,7 @@ Usage:
 
 Flags:
       --defaultErrorLevel string   change default log level(Trace,Debug,Info,Warn,Error,Fatal)
-      --defaultStatusCode int      change default status code (default -1)
+      --defaultStatusCode int      change default status code (default 500)
   -f, --file string                input go file
   -h, --help                       help for generate
 ```

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,16 +18,17 @@ package cmd
 import (
 	"bytes"
 	"fmt"
-	"github.com/fatih/color"
-	"github.com/spf13/cobra"
-	"github.com/future-architect/reguerr"
-	"github.com/future-architect/reguerr/gen"
 	"go/parser"
 	"go/token"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/fatih/color"
+	"github.com/future-architect/reguerr"
+	"github.com/future-architect/reguerr/gen"
+	"github.com/spf13/cobra"
 )
 
 var (
@@ -68,8 +69,8 @@ var generateCmd = &cobra.Command{
 
 		var opts []gen.Option
 		if errLevel != "" {
-			level, err := reguerr.NewLevel(errLevel + "Level")
-			if err != nil{
+			level, err := reguerr.NewLevel(errLevel)
+			if err != nil {
 				return err
 			}
 			opts = append(opts, gen.DefaultErrorLevel(level))


### PR DESCRIPTION
Adding the word, `Level`,  seems to be unnecessary for log level matching.